### PR TITLE
lsmcode: fix catching polymorphic type by value

### DIFF
--- a/src/output/lsmcode.cpp
+++ b/src/output/lsmcode.cpp
@@ -178,7 +178,7 @@ static string read_dt_property(const string& path, const string& attrName)
 	try {
 		attrIn.open( fullPath.c_str( ) );
 	}
-	catch (std::ifstream::failure e) {
+	catch (std::ifstream::failure &e) {
 		ostringstream os;
 		os << "Error opening " << fullPath;
 		Logger().log(os.str( ), LOG_WARNING);


### PR DESCRIPTION
Fix the compile time warning:
src/output/lsmcode.cpp: In function 'std::string read_dt_property(const string&, const string&)':
src/output/lsmcode.cpp:181:39: warning: catching polymorphic type 'class std::ios_base::failure' by value [-Wcatch-value=]
  181 |         catch (std::ifstream::failure e) {
      |                                       ^

Signed-off-by: Kamalesh Babulal <kamalesh@linux.ibm.com>