### PR TITLE
configure.ac: don't use bash syntax ==

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -54,8 +54,8 @@ AC_CHECK_LIB(sgutils2,sg_lib_version, [SGUTILS_LIB="sgutils2"],[])
 #AM_COND_IF([SGUTIL0], [], [
 #			echo "sgutils library is required for lsvpd"
 #			exit 1 ])
-AM_CONDITIONAL([SGUTIL1], [ test x$SGUTILS_LIB == xsgutils ])
-AM_CONDITIONAL([SGUTIL2], [ test x$SGUTILS_LIB == xsgutils2 ])
+AM_CONDITIONAL([SGUTIL1], [ test x$SGUTILS_LIB = xsgutils ])
+AM_CONDITIONAL([SGUTIL2], [ test x$SGUTILS_LIB = xsgutils2 ])
 PKG_CHECK_MODULES([LIBVPD2], [libvpd_cxx-2 >= 2.2.9],[],[
 			echo "VPD library(libvpd) version 2.2.9 is required for lsvpd"
 			exit 1])


### PR DESCRIPTION
otherwise build fails to detect sg3_utils like this (with non-bash /bin/sh)

```shell-session
./configure: 18016: test: xsgutils2: unexpected operator
./configure: 18024: test: xsgutils2: unexpected operator
```

and fails due to missing -lsgutils2
```shell-session
/usr/lib/gcc/powerpc64le-unknown-linux-gnu/11.3.0/../../../../powerpc64le-unknown-linux-gnu/bin/ld: sysfs_SCSI_Fill.cpp:(.text+0x3080): undefined reference to `sg_ll_inquiry
```